### PR TITLE
Remove +[UIApplication load], Remove -[UIApplication setDelegate:] swizzle

### DIFF
--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.h
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.h
@@ -29,6 +29,7 @@
 #define UIApplicationDelegate_OneSignal_h
 @interface OneSignalAppDelegate : NSObject
 
++ (void)swizzleSelectors;
 + (void)sizzlePreiOS10MethodsPhase1;
 + (void)sizzlePreiOS10MethodsPhase2;
 

--- a/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
+++ b/iOS_SDK/OneSignalSDK/Source/UIApplicationDelegate+OneSignal.m
@@ -69,17 +69,16 @@ static NSArray* delegateSubclasses = nil;
 
 
 
-- (void) setOneSignalDelegate:(id<UIApplicationDelegate>)delegate {
-    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"ONESIGNAL setOneSignalDelegate CALLED: %@", delegate]];
++ (void)swizzleSelectors {
+    [OneSignal onesignal_Log:ONE_S_LL_VERBOSE message:[NSString stringWithFormat:@"ONESIGNAL %@", NSStringFromSelector(_cmd)]];
     
     if (delegateClass) {
-        [self setOneSignalDelegate:delegate];
         return;
     }
     
     Class newClass = [OneSignalAppDelegate class];
     
-    delegateClass = getClassWithProtocolInHierarchy([delegate class], @protocol(UIApplicationDelegate));
+    delegateClass = getClassWithProtocolInHierarchy([[UIApplication sharedApplication].delegate class], @protocol(UIApplicationDelegate));
     delegateSubclasses = ClassGetSubclasses(delegateClass);
     
     // Need to keep this one for iOS 10 for content-available notifiations when the app is not in focus
@@ -94,7 +93,6 @@ static NSArray* delegateSubclasses = nil;
                         @selector(application:didFailToRegisterForRemoteNotificationsWithError:), delegateSubclasses, newClass, delegateClass);
     
     if (NSClassFromString(@"CoronaAppDelegate")) {
-        [self setOneSignalDelegate:delegate];
         return;
     }
     
@@ -116,8 +114,6 @@ static NSArray* delegateSubclasses = nil;
     // Used to track how long the app has been closed
     injectToProperClass(@selector(oneSignalApplicationWillTerminate:),
                         @selector(applicationWillTerminate:), delegateSubclasses, newClass, delegateClass);
-    
-    [self setOneSignalDelegate:delegate];
 }
 
 + (void)sizzlePreiOS10MethodsPhase1 {


### PR DESCRIPTION
- Remove +[UIApplication load] in OneSignal class implementation in order to prevent swizzling before the library is instantiated (IF it is instantiated at all)
- Remove -[UIApplication setDelegate:] swizzle in favor of manually calling +[OneSignal swizzleSelectors], which kicks off all required method swizzling. This method is also now wrapped in a dispatch_once block in order to prevent multiple swizzles from happening if init is called more than once